### PR TITLE
Add user stories for gym management platform

### DIFF
--- a/casos_de_uso.md
+++ b/casos_de_uso.md
@@ -1,0 +1,115 @@
+# Casos de Uso - Plataforma de Gestión de Gimnasio
+
+## UC-01 Gestionar registro de cliente
+- **Actor principal:** Administrador del gimnasio.
+- **Interesados y objetivos:** El administrador desea dar de alta a nuevos clientes conservando la información de contacto y emergencia para gestionar sus membresías y asistencia.
+- **Precondiciones:** El administrador ha iniciado sesión en el panel con permisos completos. El cliente ha proporcionado sus datos personales y de emergencia.
+- **Postcondiciones:** El cliente queda registrado con un perfil activo y disponible para asignarle una membresía.
+- **Flujo principal:**
+  1. El administrador accede al módulo de clientes desde el panel administrativo.
+  2. El sistema solicita los datos obligatorios del cliente (nombre, apellidos, teléfono, correo electrónico, dirección, fecha de nacimiento y contacto de emergencia).
+  3. El administrador adjunta la fotografía de perfil del cliente.
+  4. El administrador confirma el registro.
+  5. El sistema almacena la información en la base de datos, registra la auditoría y asocia la imagen en el bucket S3.
+  6. El sistema muestra el nuevo cliente en el listado general.
+- **Flujos alternos/excepciones:**
+  - 5a. Si la fotografía no puede almacenarse en S3, el sistema muestra un mensaje de error y permite reintentar la carga.
+  - 2a. Si falta información obligatoria, el sistema solicita completar los campos antes de guardar.
+
+## UC-02 Actualizar perfil desde la aplicación móvil
+- **Actor principal:** Cliente del gimnasio.
+- **Interesados y objetivos:** El cliente desea mantener actualizada su información personal para recibir notificaciones y mantener vigente su membresía.
+- **Precondiciones:** El cliente cuenta con una membresía válida, ha iniciado sesión en la app móvil y dispone de conexión a internet.
+- **Postcondiciones:** Los datos del cliente quedan actualizados y el sistema registra la auditoría correspondiente.
+- **Flujo principal:**
+  1. El cliente abre la aplicación móvil e ingresa al apartado "Mi perfil".
+  2. El sistema muestra los datos actuales del cliente.
+  3. El cliente modifica la información deseada (datos personales, contacto de emergencia o fotografía).
+  4. El cliente guarda los cambios.
+  5. El sistema envía la actualización al backend, almacena los datos y registra la auditoría.
+  6. El sistema confirma la actualización exitosa en la app.
+- **Flujos alternos/excepciones:**
+  - 5a. Si se pierde la conexión durante la actualización, la app muestra un error y permite reintentar.
+  - 3a. Si el cliente intenta modificar campos restringidos por permisos, la app informa que debe contactar al administrador.
+
+## UC-03 Gestionar membresías y pagos manuales
+- **Actor principal:** Administrador del gimnasio.
+- **Interesados y objetivos:** El administrador desea asignar membresías y registrar los pagos realizados en efectivo o transferencia.
+- **Precondiciones:** El cliente se encuentra registrado y el administrador ha iniciado sesión con permisos completos.
+- **Postcondiciones:** El cliente queda asociado a una membresía con estatus de pago actualizado.
+- **Flujo principal:**
+  1. El administrador ingresa al módulo de membresías del panel.
+  2. El sistema muestra las membresías existentes y el estado de cada cliente.
+  3. El administrador crea una nueva membresía o edita una existente seleccionando el tipo de plan y duración.
+  4. El administrador indica la forma de pago (efectivo o transferencia) y marca el pago como completado.
+  5. El sistema actualiza el estatus de la membresía, registra la auditoría y muestra la confirmación.
+- **Flujos alternos/excepciones:**
+  - 4a. Si el administrador no marca el pago como completado, el sistema mantiene el estatus pendiente y genera un recordatorio.
+  - 3a. Si se selecciona un plan con fechas superpuestas, el sistema alerta y solicita ajustar la vigencia.
+
+## UC-04 Pagar membresía con tarjeta desde la app
+- **Actor principal:** Cliente del gimnasio.
+- **Interesados y objetivos:** El cliente desea renovar o activar su membresía pagando con tarjeta de forma segura.
+- **Precondiciones:** El cliente tiene una cuenta activa en la app y dispone de un método de pago compatible con Stripe.
+- **Postcondiciones:** El pago queda procesado en Stripe, el estatus de la membresía se actualiza y el cliente recibe confirmación.
+- **Flujo principal:**
+  1. El cliente accede a la sección de membresías en la app y selecciona el plan deseado.
+  2. El sistema muestra el detalle del plan y el monto a pagar.
+  3. El cliente elige la opción "Pagar con tarjeta".
+  4. El sistema redirige al flujo de pago con Stripe y solicita los datos de la tarjeta.
+  5. Stripe procesa el pago y devuelve la confirmación al backend.
+  6. El backend actualiza el estatus de la membresía a pagada y registra la auditoría.
+  7. La app muestra un mensaje de confirmación y envía un comprobante por correo electrónico.
+- **Flujos alternos/excepciones:**
+  - 5a. Si Stripe rechaza el pago, la app informa el motivo y permite reintentar con otro método.
+  - 4a. Si el cliente cancela el flujo de pago, el sistema vuelve a la pantalla de selección sin cambios.
+
+## UC-05 Registrar asistencia mediante código QR
+- **Actor principal:** Recepcionista o administrador.
+- **Interesados y objetivos:** El personal del gimnasio desea registrar la asistencia diaria de los clientes de forma rápida y confiable.
+- **Precondiciones:** El backend generó el código único diario y los clientes cuentan con un QR vigente en la app. El recepcionista ha iniciado sesión en el panel con permisos adecuados.
+- **Postcondiciones:** La asistencia del cliente se registra con la hora de entrada, quedando disponible para reportes.
+- **Flujo principal:**
+  1. El recepcionista abre el módulo de control de asistencia en el panel.
+  2. El sistema activa la cámara o lector para escanear el QR del cliente.
+  3. El recepcionista escanea el QR desde la app del cliente.
+  4. El panel envía el código al backend para validarlo.
+  5. El backend verifica el código diario, el ID del cliente y el estatus de la membresía.
+  6. Si todo es válido, el backend registra la asistencia con fecha y hora.
+  7. El panel muestra la confirmación de asistencia exitosa.
+- **Flujos alternos/excepciones:**
+  - 5a. Si el código es inválido o expiró, el panel muestra un mensaje de error y solicita regenerarlo.
+  - 6a. Si el cliente no tiene membresía activa, el sistema deniega el registro e informa la situación.
+  - 2a. Si la cámara no funciona, el administrador puede ingresar manualmente la asistencia desde el panel.
+
+## UC-06 Configurar branding y diccionarios
+- **Actor principal:** Administrador del gimnasio.
+- **Interesados y objetivos:** El administrador busca personalizar el aspecto del panel y la app, así como mantener actualizados los idiomas disponibles.
+- **Precondiciones:** El administrador ha iniciado sesión en el panel con permisos completos.
+- **Postcondiciones:** La configuración de branding y los diccionarios de idiomas quedan actualizados para todos los canales.
+- **Flujo principal:**
+  1. El administrador accede al módulo de configuración general.
+  2. El sistema muestra las opciones de branding (logo, imágenes y paleta de cinco colores) y los diccionarios disponibles.
+  3. El administrador carga los nuevos recursos visuales y ajusta los colores.
+  4. El administrador edita los textos multilingües para español e inglés.
+  5. El administrador guarda los cambios.
+  6. El sistema aplica la configuración, actualiza los diccionarios y confirma la operación.
+- **Flujos alternos/excepciones:**
+  - 3a. Si algún recurso supera el tamaño permitido, el sistema solicita uno nuevo.
+  - 4a. Si falta una traducción obligatoria, el sistema impide guardar hasta completarla.
+
+## UC-07 Consultar métricas y exportar reportes
+- **Actor principal:** Administrador del gimnasio.
+- **Interesados y objetivos:** El administrador quiere visualizar el desempeño del gimnasio y exportar información para análisis externo.
+- **Precondiciones:** El administrador ha iniciado sesión en el panel con permisos completos y existen datos registrados en el sistema.
+- **Postcondiciones:** El administrador obtiene métricas visuales y, si lo requiere, un archivo CSV con la información filtrada.
+- **Flujo principal:**
+  1. El administrador accede al panel de métricas.
+  2. El sistema muestra gráficos y tablas de asistencia, ingresos y membresías activas/inactivas.
+  3. El administrador aplica filtros por hora, día o mes según lo requerido.
+  4. El sistema actualiza las visualizaciones con los filtros seleccionados.
+  5. El administrador solicita exportar los datos.
+  6. El sistema genera y descarga un archivo CSV con la información filtrada.
+- **Flujos alternos/excepciones:**
+  - 5a. Si no hay datos para el rango seleccionado, el sistema muestra un mensaje de "sin resultados" y deshabilita la exportación.
+  - 6a. Si ocurre un error durante la generación del archivo, el sistema notifica y permite reintentar.

--- a/historias_de_usuario.md
+++ b/historias_de_usuario.md
@@ -1,0 +1,89 @@
+# Historias de Usuario - Plataforma de Gestión de Gimnasio
+
+## HU-01 Registrar clientes desde el panel administrativo
+- **Como** administrador del gimnasio
+- **Quiero** capturar la información completa de un nuevo cliente y su contacto de emergencia
+- **Para** mantener un registro actualizado que permita gestionar membresías y asistencia
+- **Criterios de aceptación:**
+  - Dado que accedo al módulo de clientes, cuando completo los datos obligatorios del cliente y guardo, entonces el sistema debe almacenar la información y mostrar al cliente en el listado general. (RF-2.1, RF-2.3)
+  - Dado que adjunto una fotografía válida, cuando confirmo el registro, entonces el sistema debe almacenarla en el repositorio definido y asociarla al cliente. (RF-2.2)
+  - Dado que omito un campo obligatorio, cuando intento guardar, entonces el sistema debe indicar los campos faltantes y evitar el registro hasta completarlos. (RF-2.3)
+
+## HU-02 Actualizar perfil personal desde la app móvil
+- **Como** cliente del gimnasio
+- **Quiero** modificar mis datos personales y de contacto desde la aplicación móvil
+- **Para** asegurar que la información del gimnasio esté siempre vigente
+- **Criterios de aceptación:**
+  - Dado que inicio sesión en la app, cuando abro la sección "Mi perfil", entonces debo visualizar mis datos actuales para editarlos. (RF-6.1)
+  - Dado que actualizo mis datos y guardo los cambios, cuando la operación sea exitosa, entonces debo recibir una confirmación y la información debe quedar sincronizada en el backend. (RF-2.4, RF-6.1)
+  - Dado que pierdo conexión durante la actualización, cuando el sistema no pueda guardar los cambios, entonces debe informarme del error y permitirme reintentar. (UC-02)
+
+## HU-03 Gestionar membresías y pagos manuales
+- **Como** administrador del gimnasio
+- **Quiero** asignar planes de membresía y registrar pagos en efectivo o transferencia
+- **Para** mantener actualizado el estatus de pago de cada cliente
+- **Criterios de aceptación:**
+  - Dado que selecciono un cliente, cuando elijo un tipo de plan y duración, entonces el sistema debe crear o actualizar la membresía con esas condiciones. (RF-3.1)
+  - Dado que recibo un pago en efectivo o transferencia, cuando lo marco como completado, entonces el estatus de la membresía debe reflejarse como pagado. (RF-3.2)
+  - Dado que existe un solapamiento de fechas, cuando intento guardar, entonces el sistema debe alertarme y solicitar ajustes antes de confirmar. (UC-03)
+
+## HU-04 Pagar membresía con tarjeta desde la app
+- **Como** cliente del gimnasio
+- **Quiero** completar el pago de mi membresía mediante tarjeta dentro de la aplicación móvil
+- **Para** renovar mi acceso sin depender de pagos presenciales
+- **Criterios de aceptación:**
+  - Dado que tengo una membresía pendiente por pagar, cuando elijo la opción de pagar con tarjeta, entonces debo ser dirigido al flujo seguro de Stripe. (RF-3.3, RF-6.4)
+  - Dado que Stripe confirma el pago, cuando se procese correctamente, entonces el sistema debe actualizar el estatus de mi membresía y enviar la confirmación correspondiente. (RF-3.3)
+  - Dado que el pago es rechazado, cuando Stripe devuelva un error, entonces la app debe notificarme el motivo y permitir reintentar o elegir otro método. (UC-04)
+
+## HU-05 Registrar asistencia escaneando código QR
+- **Como** recepcionista del gimnasio
+- **Quiero** escanear el código QR de los clientes para registrar su asistencia diaria
+- **Para** llevar un control rápido y preciso de los ingresos al gimnasio
+- **Criterios de aceptación:**
+  - Dado que el cliente presenta su QR vigente, cuando lo escaneo desde el panel, entonces el sistema debe validar el código diario y registrar la hora de entrada. (RF-4.1, RF-4.2, RF-4.3, RF-4.4)
+  - Dado que el cliente no tiene membresía activa o el código es inválido, cuando intento registrar la asistencia, entonces el sistema debe mostrar un mensaje de error específico. (RF-4.3, UC-05)
+  - Dado que el lector falla, cuando no sea posible escanear el QR, entonces debo contar con la opción de registrar la asistencia manualmente. (RF-4.5)
+
+## HU-06 Regenerar código diario de asistencia
+- **Como** administrador del gimnasio
+- **Quiero** regenerar el código único diario en caso de contingencia
+- **Para** garantizar que los clientes puedan seguir registrando su asistencia
+- **Criterios de aceptación:**
+  - Dado que detecto un problema con el código diario, cuando utilizo la opción de regenerarlo desde el panel, entonces el backend debe crear un nuevo código válido para todos los clientes. (RF-4.6)
+  - Dado que se genera un nuevo código, cuando los clientes refresquen su app, entonces deben obtener el nuevo QR actualizado. (RF-4.2)
+
+## HU-07 Configurar branding y diccionarios multilingües
+- **Como** administrador del gimnasio
+- **Quiero** personalizar el branding y actualizar los textos en múltiples idiomas
+- **Para** mantener la identidad visual y comunicativa del gimnasio en todos los canales
+- **Criterios de aceptación:**
+  - Dado que accedo a la configuración general, cuando actualizo logo, imágenes y colores permitidos, entonces el sistema debe aplicar los cambios a la app y al panel. (RF-1.2)
+  - Dado que edito los diccionarios de español e inglés, cuando guardo la configuración, entonces los textos deben quedar disponibles para ambos idiomas. (RF-1.3)
+  - Dado que falta una traducción obligatoria, cuando intento guardar, entonces el sistema debe impedir la operación y solicitar completar la información. (UC-06)
+
+## HU-08 Configurar recordatorios de vencimiento
+- **Como** administrador del gimnasio
+- **Quiero** definir el contenido y la anticipación de los recordatorios de membresía
+- **Para** mantener informados a los clientes sobre sus vencimientos
+- **Criterios de aceptación:**
+  - Dado que selecciono un tipo de membresía, cuando configuro la anticipación del recordatorio, entonces el sistema debe guardar la programación para enviar notificaciones y correos. (RF-3.4)
+  - Dado que edito el contenido de un recordatorio, cuando guardo los cambios, entonces debe actualizarse tanto para correo como para notificación push. (RF-8.1, RF-8.2)
+
+## HU-09 Consultar métricas y exportar reportes
+- **Como** administrador del gimnasio
+- **Quiero** revisar estadísticas de asistencia e ingresos y exportarlas a CSV
+- **Para** analizar el desempeño del gimnasio y compartir información
+- **Criterios de aceptación:**
+  - Dado que accedo al panel de métricas, cuando aplico filtros por hora, día o mes, entonces el sistema debe actualizar las visualizaciones correspondientes. (RF-7.1)
+  - Dado que necesito revisar membresías activas o inactivas, cuando consulto las métricas, entonces debo ver los totales actualizados. (RF-7.2)
+  - Dado que deseo respaldar la información, cuando solicito la exportación, entonces el sistema debe generar un archivo CSV con los datos filtrados. (RF-7.3)
+
+## HU-10 Llevar control de rutina diaria
+- **Como** cliente del gimnasio
+- **Quiero** marcar mi avance en un checklist diario de ejercicios desde la app
+- **Para** dar seguimiento a mi rutina personal
+- **Criterios de aceptación:**
+  - Dado que accedo a la sección de rutina, cuando visualizo el checklist del día, entonces debo poder marcar cada elemento completado. (RF-6.5)
+  - Dado que finalizo el checklist, cuando marco todos los elementos, entonces el sistema debe guardar mi progreso y mostrar una confirmación. (RF-6.5)
+  - Dado que regreso posteriormente, cuando consulto mi rutina, entonces debo ver el estado actualizado de mis marcas. (RF-6.5)


### PR DESCRIPTION
## Summary
- add a new `historias_de_usuario.md` document capturing ten key user stories for the gym management solution
- detail actors, objectives and acceptance criteria aligned with functional requirements and existing use cases

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e70c6aca1483259b7cf250d54064bd