### PR TITLE
Remove audit artifacts from documentation

### DIFF
--- a/casos_de_uso.md
+++ b/casos_de_uso.md
@@ -10,7 +10,7 @@
   2. El sistema solicita los datos obligatorios del cliente (nombre, apellidos, teléfono, correo electrónico, dirección, fecha de nacimiento y contacto de emergencia).
   3. El administrador adjunta la fotografía de perfil del cliente.
   4. El administrador confirma el registro.
-  5. El sistema almacena la información en la base de datos, registra la auditoría y asocia la imagen en el bucket S3.
+  5. El sistema almacena la información en la base de datos y asocia la imagen en el bucket S3.
   6. El sistema muestra el nuevo cliente en el listado general.
 - **Flujos alternos/excepciones:**
   - 5a. Si la fotografía no puede almacenarse en S3, el sistema muestra un mensaje de error y permite reintentar la carga.
@@ -20,13 +20,13 @@
 - **Actor principal:** Cliente del gimnasio.
 - **Interesados y objetivos:** El cliente desea mantener actualizada su información personal para recibir notificaciones y mantener vigente su membresía.
 - **Precondiciones:** El cliente cuenta con una membresía válida, ha iniciado sesión en la app móvil y dispone de conexión a internet.
-- **Postcondiciones:** Los datos del cliente quedan actualizados y el sistema registra la auditoría correspondiente.
+- **Postcondiciones:** Los datos del cliente quedan actualizados en la base de datos.
 - **Flujo principal:**
   1. El cliente abre la aplicación móvil e ingresa al apartado "Mi perfil".
   2. El sistema muestra los datos actuales del cliente.
   3. El cliente modifica la información deseada (datos personales, contacto de emergencia o fotografía).
   4. El cliente guarda los cambios.
-  5. El sistema envía la actualización al backend, almacena los datos y registra la auditoría.
+  5. El sistema envía la actualización al backend y almacena los datos.
   6. El sistema confirma la actualización exitosa en la app.
 - **Flujos alternos/excepciones:**
   - 5a. Si se pierde la conexión durante la actualización, la app muestra un error y permite reintentar.
@@ -42,7 +42,7 @@
   2. El sistema muestra las membresías existentes y el estado de cada cliente.
   3. El administrador crea una nueva membresía o edita una existente seleccionando el tipo de plan y duración.
   4. El administrador indica la forma de pago (efectivo o transferencia) y marca el pago como completado.
-  5. El sistema actualiza el estatus de la membresía, registra la auditoría y muestra la confirmación.
+  5. El sistema actualiza el estatus de la membresía y muestra la confirmación.
 - **Flujos alternos/excepciones:**
   - 4a. Si el administrador no marca el pago como completado, el sistema mantiene el estatus pendiente y genera un recordatorio.
   - 3a. Si se selecciona un plan con fechas superpuestas, el sistema alerta y solicita ajustar la vigencia.
@@ -58,7 +58,7 @@
   3. El cliente elige la opción "Pagar con tarjeta".
   4. El sistema redirige al flujo de pago con Stripe y solicita los datos de la tarjeta.
   5. Stripe procesa el pago y devuelve la confirmación al backend.
-  6. El backend actualiza el estatus de la membresía a pagada y registra la auditoría.
+  6. El backend actualiza el estatus de la membresía a pagada.
   7. La app muestra un mensaje de confirmación y envía un comprobante por correo electrónico.
 - **Flujos alternos/excepciones:**
   - 5a. Si Stripe rechaza el pago, la app informa el motivo y permite reintentar con otro método.

--- a/diagrama_relacional.md
+++ b/diagrama_relacional.md
@@ -178,15 +178,6 @@ erDiagram
         uuid creado_por_usuario_id
         uuid actualizado_por_usuario_id
     }
-    AUDITORIAS {
-        uuid id PK
-        uuid usuario_id
-        string entidad
-        uuid entidad_id
-        string accion
-        json cambios
-        timestamp realizado_en
-    }
 
     ROLES ||--o{ USUARIOS : asigna
     IDIOMAS ||--o{ GIMNASIO_CONFIGURACION : "se usa como predeterminado"
@@ -202,5 +193,4 @@ erDiagram
     CLIENTES ||--o{ CHECKLISTS_DIARIOS : "completa"
     CHECKLISTS_DIARIOS ||--o{ CHECKLIST_ITEMS : "incluye"
     CLIENTES ||--o{ NOTIFICACIONES_PUSH : recibe
-    USUARIOS ||--o{ AUDITORIAS : realiza
 ```

--- a/diagramas_secuencia.md
+++ b/diagramas_secuencia.md
@@ -19,7 +19,6 @@ sequenceDiagram
     Backend->>S3: Almacenar fotografía de perfil
     alt Carga de fotografía exitosa
         S3-->>Backend: Confirmación de carga
-        Backend->>DB: Registrar auditoría del alta
         DB-->>Backend: Confirmación de guardado
         Backend-->>Panel: Cliente creado correctamente
         Panel-->>Administrador: Mostrar cliente en listado
@@ -45,7 +44,6 @@ sequenceDiagram
     Cliente->>App: Modificar información y guardar cambios
     App->>Backend: Enviar actualización del perfil
     Backend->>DB: Actualizar datos del cliente
-    Backend->>DB: Registrar auditoría de modificación
     DB-->>Backend: Confirmaciones de guardado
     Backend-->>App: Confirmar actualización exitosa
     App-->>Cliente: Mostrar mensaje de éxito
@@ -72,7 +70,7 @@ sequenceDiagram
     Backend->>DB: Guardar o actualizar membresía
     Administrador->>Panel: Indicar forma de pago y marcar completado
     Panel->>Backend: Registrar pago manual
-    Backend->>DB: Actualizar estatus de pago y auditoría
+    Backend->>DB: Actualizar estatus de pago
     DB-->>Backend: Confirmación de actualización
     Backend-->>Panel: Notificar membresía actualizada
     Panel-->>Administrador: Mostrar confirmación
@@ -102,7 +100,6 @@ sequenceDiagram
     Stripe->>Backend: Enviar resultado del procesamiento
     alt Pago aprobado
         Backend->>DB: Actualizar estatus de membresía
-        Backend->>DB: Registrar auditoría del pago
         DB-->>Backend: Confirmaciones de guardado
         Backend-->>App: Notificar pago aprobado
         App-->>Cliente: Mostrar confirmación y enviar comprobante

--- a/endpoints_por_entregable.md
+++ b/endpoints_por_entregable.md
@@ -3,7 +3,7 @@
 A continuación se listan los endpoints REST propuestos para el backend de GymApp, organizados en entregables incrementales. Cada grupo describe el objetivo funcional del bloque y los recursos involucrados.
 
 ## Entregable 1: Autenticación y gestión básica de usuarios administrativos
-Este entregable habilita la infraestructura mínima de seguridad para que administradores y recepcionistas puedan acceder al panel, manteniendo los roles diferenciados y auditables.
+Este entregable habilita la infraestructura mínima de seguridad para que administradores y recepcionistas puedan acceder al panel, manteniendo los roles diferenciados.
 
 | Método | Endpoint | Descripción |
 |--------|----------|-------------|
@@ -15,7 +15,6 @@ Este entregable habilita la infraestructura mínima de seguridad para que admini
 | POST | `/admin/users` | Crea un usuario administrativo (solo rol administrador). |
 | PATCH | `/admin/users/{user_id}` | Actualiza datos y rol de un usuario administrativo. |
 | DELETE | `/admin/users/{user_id}` | Realiza borrado lógico de un usuario administrativo. |
-| GET | `/admin/audit-logs` | Consulta los eventos de auditoría generados por acciones administrativas. |
 
 ## Entregable 2: Gestión de clientes y perfiles
 Establece los recursos para registrar clientes, almacenar su información completa y permitir que cada uno administre su perfil desde la aplicación móvil.

--- a/levantamiento_requerimientos.md
+++ b/levantamiento_requerimientos.md
@@ -110,10 +110,6 @@ Se utilizará autenticación basada en JWT.
 
 Se estima un máximo de 200 usuarios por día y hasta 20 usuarios concurrentes.
 
-**¿Hay requerimientos específicos de auditoría o registro de eventos?**
-
-Se debe registrar fecha, hora y usuario responsable en cada alta, modificación o eliminación, además de implementar borrado lógico.
-
 ## Frontend Móvil para Clientes
 
 **¿Qué funcionalidades adicionales desea el cliente en la app móvil (ver historial de asistencias, renovar membresía, etc.)?**

--- a/requerimientos_funcionales.md
+++ b/requerimientos_funcionales.md
@@ -29,7 +29,6 @@
 
 ## 5. Backend y Base de Datos
 - RF-5.1 El backend debe exponer APIs para la gestión de clientes, membresías, pagos, asistencia, recordatorios y configuración de branding.
-- RF-5.2 El sistema debe almacenar auditorías registrando fecha, hora y usuario responsable de cada alta, modificación o eliminación, y conservar los registros mediante borrado lógico.
 
 ## 6. Aplicación Móvil (Clientes)
 - RF-6.1 La app móvil debe permitir a los clientes registrarse, iniciar sesión y actualizar sus datos.

--- a/requerimientos_gimnasio.md
+++ b/requerimientos_gimnasio.md
@@ -34,7 +34,6 @@
 2. ¿Se necesita exponer APIs adicionales para integraciones con terceros?
 3. ¿Qué políticas de seguridad y autenticación se requieren (JWT, OAuth, 2FA)?
 4. ¿Qué volumen de usuarios y asistencias se estima para dimensionar la infraestructura?
-5. ¿Hay requerimientos específicos de auditoría o registro de eventos?
 
 ## Frontend Móvil para Clientes
 1. ¿Qué funcionalidades adicionales desea el cliente en la app móvil (ver historial de asistencias, renovar membresía, etc.)?

--- a/requerimientos_no_funcionales.md
+++ b/requerimientos_no_funcionales.md
@@ -12,8 +12,7 @@
 ## 3. Seguridad
 - RNF-3.1 El backend debe implementar autenticación basada en JWT para el acceso a las APIs.
 - RNF-3.2 Los roles de Administrador y Recepcionista deben tener permisos diferenciados, asegurando que solo el administrador posea privilegios totales.
-- RNF-3.3 El sistema debe conservar auditorías de operaciones (fecha, hora y usuario) y aplicar borrado lógico para preservar la trazabilidad.
-- RNF-3.4 Los datos sensibles, incluidas las fotografías de perfil almacenadas en S3 y la información de pago procesada por Stripe, deben transmitirse mediante canales seguros (HTTPS).
+- RNF-3.3 Los datos sensibles, incluidas las fotografías de perfil almacenadas en S3 y la información de pago procesada por Stripe, deben transmitirse mediante canales seguros (HTTPS).
 
 ## 4. Disponibilidad y Recuperación
 - RNF-4.1 El sistema no requiere niveles especiales de disponibilidad en esta fase, pero debe garantizar la continuidad básica del servicio durante el horario operativo del gimnasio.


### PR DESCRIPTION
## Summary
- remove the audit table from the ER diagram
- delete audit-related endpoints, requirements, and use-case references across the documentation set

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e84da390708325b74356d16c881a24